### PR TITLE
Fix broken content items on music home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Introduction
 
-`YouTubeApi` is a music-focused client interface for the internal API's of YouTube and YouTube Music. Some of it's functionality includes:
+`YouTubeApi` is a music-focused client interface for the internal API's of YouTube and YouTube Music. Through reverse engineering, the client is able to work without the use of official YouTube API keys. This allows the client to bypass normal restrictions and usage quotas that are enforced by the official API. 
+
+Some of it's functionality includes:
 
 - Performing searches
 - Getting raw audio or video stream URL's

--- a/YouTubeApi.Tests/YouTubeApiSpecs.cs
+++ b/YouTubeApi.Tests/YouTubeApiSpecs.cs
@@ -1,6 +1,5 @@
 namespace YouTubeApi.Tests;
 
-using System.Buffers;
 using YouTubeApi;
 
 [TestClass]

--- a/YouTubeApi.Tests/YouTubeApiSpecs.cs
+++ b/YouTubeApi.Tests/YouTubeApiSpecs.cs
@@ -140,9 +140,9 @@ public class YouTubeApiSpecs
     }
 
     [DataTestMethod]
-    [DataRow("https://www.youtube.com/watch?v=mQER0A0ej0M")]
-    [DataRow("https://www.youtube.com/watch?v=q-JJf7S0osI&pp=ygUKcm9jayBtdXNpYw%3D%3D")]
-    [DataRow("https://www.youtube.com/watch?v=S-OgkNgxm3k&pp=ygUKcm9jayBtdXNpYw%3D%3D")]
+    [DataRow("https://www.youtube.com/watch?v=zOILAZHf2pE")]
+    [DataRow("https://www.youtube.com/watch?v=YChioDnHxm4")]
+    [DataRow("https://www.youtube.com/watch?v=QdBZY2fkU-0")]
     public async Task GetRelatedVideos_VideoUrlsInput_Retrieves_MultiplePagesOfRelatedVideos(
         string url
     )

--- a/YouTubeApi/YouTube.JsonParsers.cs
+++ b/YouTubeApi/YouTube.JsonParsers.cs
@@ -439,14 +439,27 @@ public static partial class YouTube
             try
             {
                 playlistId = (string?)
-                    compactStationRenderer?["navigationEndpoint"]?["watchEndpoint"]?["playlistId"];
+                    compactStationRenderer
+                        ?["navigationEndpoint"]
+                        ?["watchPlaylistEndpoint"]
+                        ?["playlistId"];
                 title = (string?)compactStationRenderer?["title"]?["simpleText"];
                 var thumbnailVideoId = (string?)
-                    compactStationRenderer?["navigationEndpoint"]?["watchEndpoint"]?["videoId"];
-                thumbnails =
-                    thumbnailVideoId != null
-                        ? new Thumbnails() { VideoId = thumbnailVideoId, }
-                        : null;
+                    compactStationRenderer
+                        ?["navigationEndpoint"]
+                        ?["watchPlaylistEndpoint"]
+                        ?["videoId"];
+                thumbnails = new Thumbnails()
+                {
+                    LowResUrl = (string?)
+                        compactStationRenderer?["thumbnail"]?["thumbnails"]?[0]?["url"],
+                    MediumResUrl = (string?)
+                        compactStationRenderer?["thumbnail"]?["thumbnails"]?[1]?["url"],
+                    HighResUrl = (string?)
+                        compactStationRenderer?["thumbnail"]?["thumbnails"]?[2]?["url"],
+                    StandardResUrl = (string?)
+                        compactStationRenderer?["thumbnail"]?["thumbnails"]?[1]?["url"]
+                };
                 description = (string?)compactStationRenderer?["description"]?["simpleText"];
                 videoCount = int.Parse(
                     (string?)

--- a/YouTubeApi/YouTube.JsonParsers.cs
+++ b/YouTubeApi/YouTube.JsonParsers.cs
@@ -472,7 +472,12 @@ public static partial class YouTube
                 return null;
             }
 
-            if (playlistId != null && title != null && description != null && thumbnails != null)
+            if (
+                playlistId != null
+                && title != null
+                && description != null
+                && thumbnails.StandardResUrl != null
+            )
                 return new Playlist(
                     playlistId,
                     title,
@@ -530,7 +535,7 @@ public static partial class YouTube
                 && author != null
                 && description != null
                 && videoCount > 0
-                && thumbnails != null
+                && thumbnails?.StandardResUrl != null
             )
                 return new Playlist(playlistId, title, author, description, videoCount, thumbnails);
             else
@@ -580,7 +585,7 @@ public static partial class YouTube
                 && title != null
                 && author != null
                 && videoCount > 0
-                && thumbnails != null
+                && thumbnails.StandardResUrl != null
             )
                 return new Playlist(
                     playlistId,
@@ -659,6 +664,8 @@ public static partial class YouTube
 
                 if (thumbnailItems?.Count() >= 4)
                     thumbnails.StandardResUrl = (string?)thumbnailItems[3]?["url"];
+                else if (thumbnails.MediumResUrl != null)
+                    thumbnails.StandardResUrl = thumbnails.MediumResUrl;
 
                 // Check if the text run element contains video count information
                 if (textRun != null && Regex.IsMatch(textRun, @"^\d+ song[s]*"))
@@ -678,7 +685,12 @@ public static partial class YouTube
                 return null;
             }
 
-            if (playlistId != null && title != null && author != null && thumbnails != null)
+            if (
+                playlistId != null
+                && title != null
+                && author != null
+                && thumbnails.StandardResUrl != null
+            )
                 return new Playlist(
                     playlistId,
                     title,


### PR DESCRIPTION
- Fix music home page content item parsing logic broken by YouTube JSON changes.
- Fix / update tests.
- Add unrelated clarification to README.