### PR TITLE
Fix broken stream URL requests by updating YouTube client versions

### DIFF
--- a/YouTubeApi/YouTube.Constants.cs
+++ b/YouTubeApi/YouTube.Constants.cs
@@ -28,6 +28,6 @@ public static partial class YouTube
 
         // Header Data
         public const string UserAgent =
-            "com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip";
+            "com.google.android.youtube/18.11.34 (Linux; U; Android 11) gzip";
     }
 }

--- a/YouTubeApi/YouTube.Network.cs
+++ b/YouTubeApi/YouTube.Network.cs
@@ -143,7 +143,7 @@ public static partial class YouTube
         private static JObject GetYouTubeStreamInfoContextJson()
         {
             return JObject.Parse(
-                @"{'context':{'client':{'clientName':'ANDROID','clientVersion':'17.31.35', 'androidSdkVersion': 33}}}"
+                @"{'context':{'client':{'clientName':'ANDROID','clientVersion':'18.11.34', 'androidSdkVersion': 30}}}"
             );
         }
     }


### PR DESCRIPTION
This PR updates the minimum client versions in the `User-Agent` and YouTube context payload that are needed to work with the YouTube API's.