### PR TITLE
Fix null playlist description bug

### DIFF
--- a/YouTubeApi/YouTube.JsonParsers.cs
+++ b/YouTubeApi/YouTube.JsonParsers.cs
@@ -472,12 +472,7 @@ public static partial class YouTube
                 return null;
             }
 
-            if (
-                playlistId != null
-                && title != null
-                && description != null
-                && thumbnails.StandardResUrl != null
-            )
+            if (playlistId != null && title != null && thumbnails.StandardResUrl != null)
                 return new Playlist(
                     playlistId,
                     title,


### PR DESCRIPTION
Allows a valid `Playlist` to be parsed from `compactStationRenderer` with a null description field, which is new due to YouTube changes to the music home page.