### PR TITLE
Skip failing tests

### DIFF
--- a/YouTubeApi.Tests/YouTubeApiSpecs.cs
+++ b/YouTubeApi.Tests/YouTubeApiSpecs.cs
@@ -61,6 +61,7 @@ public class YouTubeApiSpecs
         }
     }
 
+    [Ignore] // Ignored due to YouTube blocking these requests when tests run on Github.
     [DataTestMethod]
     [DataRow("https://www.youtube.com/watch?v=mQER0A0ej0M")]
     [DataRow("https://www.youtube.com/watch?v=pcAKbKUBUOQ&list=PLI1gW6hB0ahz9iGkYKld6Mtfa-VD1Pqun")]


### PR DESCRIPTION
Skip stream info testing since YouTube requests are now getting blocked as bot traffic when they are made from Github.